### PR TITLE
Chrome extension link broken when opened from files changed tab in GitHub

### DIFF
--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -15,5 +15,7 @@ esbuild
   })
   .then(() => {
     fs.copySync('./public', './dist');
+
+    console.log('🎉 Build complete!');
   })
   .catch(() => process.exit(1));

--- a/src/pr-content-script.ts
+++ b/src/pr-content-script.ts
@@ -2,6 +2,20 @@ const VIEW_ON_GRAPHITE_ID = 'view-on-graphite';
 const TAB_ICON =
   '<svg style="margin-right: 6px; vertical-align: text-bottom;" xmlns="http://www.w3.org/2000/svg" height=16 width=16 viewBox="0 0 16 16"><path fill="currentColor" d="M9.7932,1.3079L3.101,3.101l-1.7932,6.6921,4.899,4.899,6.6921-1.7931,1.7932-6.6921L9.7932,1.3079Zm1.0936,11.6921H5.1133l-2.8867-5L5.1133,3h5.7735l2.8867,5-2.8867,5Z"/><polygon fill="currentColor" points="11.3504 4.6496 6.7737 3.4232 3.4232 6.7737 4.6496 11.3504 9.2263 12.5768 12.5768 9.2263 11.3504 4.6496"/></svg>';
 
+function getGraphitePRUrl(): string | null {
+  const matches = document.URL.match(/\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+
+  if (matches) {
+    const organization = matches[1];
+    const repoName = matches[2];
+    const pullRequestId = matches[3];
+
+    return `https://app.graphite.dev/github/${organization}/${repoName}/pull/${pullRequestId}`;
+  } else {
+    return null;
+  }
+}
+
 function addViewOnGraphiteButton() {
   if (document.getElementById(VIEW_ON_GRAPHITE_ID)) {
     return;
@@ -12,10 +26,15 @@ function addViewOnGraphiteButton() {
     return;
   }
 
+  const graphiteUrl = getGraphitePRUrl();
+  if (!graphiteUrl) {
+    return;
+  }
+
   const a = document.createElement('a');
   a.id = VIEW_ON_GRAPHITE_ID;
   a.className = 'tabnav-tab flex-shrink-0';
-  a.href = document.URL.replace('github.com', 'app.graphite.dev/github');
+  a.href = graphiteUrl;
   a.innerHTML = TAB_ICON + 'View this PR on Graphite';
 
   tabs.appendChild(a);


### PR DESCRIPTION
**Context:**



**Changes In This Pull Request:**



**Test Plan:**
:


### Linear

:sparkles: **Chrome extension link broken when opened from files changed tab in GitHub**
:globe_with_meridians: [GT-8530](https://linear.app/withgraphite/issue/GT-8530/chrome-extension-link-broken-when-opened-from-files-changed-tab-in)

<details>
  <summary>Description</summary>

  ![Screenshot 2023-04-21 at 10.49.05 AM.png](https://uploads.linear.app/24f8a1a2-bac0-4c2a-94b6-d23224c57e6f/4d23281b-4ec9-4089-84de-89bcc61c633e/56823398-3dbc-46b0-9a81-70f8d12a0be6)
</details>

Closes GT-8530
