### PR TITLE
Add a success message when running yarn build

### DIFF
--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -15,5 +15,7 @@ esbuild
   })
   .then(() => {
     fs.copySync('./public', './dist');
+
+    console.log('🎉 Build complete!');
   })
   .catch(() => process.exit(1));


### PR DESCRIPTION
**Context:**

When running `yarn build`, there is no success output. This made me feel
like it wasn't running correctly, when it definitely was!

**Changes In This Pull Request:**

Adds a `console.log()` on build.

**Test Plan:**

Ran it, it printed.
