### PR TITLE
Remove console.log + enforce no logs in builds via eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,11 +4,22 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "rules": {
+    "no-console": "error",
     "@typescript-eslint/no-floating-promises": "error",
-    "max-lines-per-function": ["error", { "max": 120 }],
-    "@typescript-eslint/explicit-module-boundary-types": "error",
+    "max-lines-per-function": [
+      "error",
+      {
+        "max": 120
+      }
+    ],
+    "@typescript-eslint/explicit-module-boundary-types": "error"
   },
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"]
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ]
 }

--- a/src/pr-content-script.ts
+++ b/src/pr-content-script.ts
@@ -74,7 +74,6 @@ function addMergeWarning() {
 }
 
 function addGraphiteElements() {
-  console.log('addGraphiteElements');
   addViewOnGraphiteButton();
   addMergeWarning();
 }


### PR DESCRIPTION
**Context:**
We had a stray `console.log`


**Changes In This Pull Request:**
- Remove the `console.log`
- Ban future log lines via `eslint`


**Test Plan:**
Ran `eslint` and verified it yelled at me for `console.log` statements.
